### PR TITLE
ibis implementation

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -24,9 +24,10 @@ test:
   source_files:
     - tests
   requires:
+    - coverage
+    - ibis-framework
     - pytest
     - pytest-cov
-    - coverage
   commands:
     - py.test --verbose --cov=intake_sql tests
 

--- a/intake_sql/intake_sql.py
+++ b/intake_sql/intake_sql.py
@@ -332,23 +332,18 @@ def make_ibis_client(uri):
     uri: str
         connection string (sql sqlalchemy documentation)
     """
-    try:
-        import sqlalchemy
-        url = sqlalchemy.engine.url.make_url(uri)
-        dialect = url.get_dialect()
-        name = dialect.name
-        if name == "postgresql":
-            import ibis
-            return ibis.postgres.connect(url=uri)
-        elif name == "mysql":
-            import ibis
-            return ibis.mysql.connect(url=uri)
-        elif name == "sqlite":
-            import ibis
-            return ibis.sqlite.connect(path=url.database)
-        else:
-            raise ValueError(f"Unable to create an ibis connection for {uri}")
-    except Exception as e:
-        raise e
-
+    import sqlalchemy
+    url = sqlalchemy.engine.url.make_url(uri)
+    dialect = url.get_dialect()
+    name = dialect.name
+    if name == "postgresql":
+        import ibis
+        return ibis.postgres.connect(url=uri)
+    elif name == "mysql":
+        import ibis
+        return ibis.mysql.connect(url=uri)
+    elif name == "sqlite":
+        import ibis
+        return ibis.sqlite.connect(path=url.database)
+    else:
         raise ValueError(f"Unable to create an ibis connection for {uri}")

--- a/intake_sql/intake_sql.py
+++ b/intake_sql/intake_sql.py
@@ -61,6 +61,18 @@ class SQLSource(base.DataSource):
     def read(self):
         return self._get_partition(None)
 
+    def to_ibis(self):
+        """
+        Create an ibis expression for the data source.
+        The sql_expr for the source must be a table, not a table expression.
+        The ibis expression is not partitioned.
+        """
+        client = make_ibis_client(self._uri)
+        if self._sql_expr not in client.list_tables():
+            raise ValueError("Only full tables can be used in to_ibis")
+        else:
+            return client.table(self._sql_expr)
+
     def _close(self):
         self._dataframe = None
 
@@ -132,6 +144,19 @@ class SQLSourceAutoPartition(base.DataSource):
     def to_dask(self):
         self._get_schema()
         return self._dataframe
+
+    def to_ibis(self):
+        """
+        Create an ibis expression for the data source.
+        The sql_expr for the source must be a table, not a table expression.
+        The ibis expression is not partitioned.
+        """
+        client = make_ibis_client(self._uri)
+        if self._sql_expr not in client.list_tables():
+            raise ValueError("Only full tables can be used in to_ibis")
+        else:
+            return client.table(self._sql_expr)
+
 
     def read(self):
         self._get_schema()
@@ -224,6 +249,18 @@ class SQLSourceManualPartition(base.DataSource):
         self._get_schema()
         return self._dataframe
 
+    def to_ibis(self):
+        """
+        Create an ibis expression for the data source.
+        The sql_expr for the source must be a table, not a table expression.
+        The ibis expression is not partitioned.
+        """
+        client = make_ibis_client(self._uri)
+        if self._sql_expr not in client.list_tables():
+            raise ValueError("Only full tables can be used in to_ibis")
+        else:
+            return client.table(self._sql_expr)
+
     def read(self):
         self._get_schema()
         return self._dataframe.compute()
@@ -279,3 +316,39 @@ def read_sql_query(uri, sql, where, where_tmp=None, meta=None, kwargs=None):
     dload = dask.delayed(load_part)
     parts = [dload(sql, uri, w, kwargs) for w in where]
     return dd.from_delayed(parts, meta=meta)
+
+
+def make_ibis_client(uri):
+    """
+    Create an ibis client from a SQLAlchemy connection string.
+
+    Currently targets existing ibis backends that use SQLAlchemy, namely
+        MySQL
+        PostgreSQL
+        SQLite
+
+    Parameters
+    ----------
+    uri: str
+        connection string (sql sqlalchemy documentation)
+    """
+    try:
+        import sqlalchemy
+        url = sqlalchemy.engine.url.make_url(uri)
+        dialect = url.get_dialect()
+        name = dialect.name
+        if name == "postgresql":
+            import ibis
+            return ibis.postgres.connect(url=uri)
+        elif name == "mysql":
+            import ibis
+            return ibis.mysql.connect(url=uri)
+        elif name == "sqlite":
+            import ibis
+            return ibis.sqlite.connect(path=url.database)
+        else:
+            raise ValueError(f"Unable to create an ibis connection for {uri}")
+    except Exception as e:
+        raise e
+
+        raise ValueError(f"Unable to create an ibis connection for {uri}")

--- a/intake_sql/intake_sql.py
+++ b/intake_sql/intake_sql.py
@@ -69,6 +69,8 @@ class SQLSource(base.DataSource):
         """
         client = make_ibis_client(self._uri)
         if self._sql_expr not in client.list_tables():
+            # SQLAlchemy-based ibis clients don't currently have
+            # client.sql() implemented.
             raise ValueError("Only full tables can be used in to_ibis")
         else:
             return client.table(self._sql_expr)
@@ -153,6 +155,8 @@ class SQLSourceAutoPartition(base.DataSource):
         """
         client = make_ibis_client(self._uri)
         if self._sql_expr not in client.list_tables():
+            # SQLAlchemy-based ibis clients don't currently have
+            # client.sql() implemented.
             raise ValueError("Only full tables can be used in to_ibis")
         else:
             return client.table(self._sql_expr)
@@ -248,18 +252,6 @@ class SQLSourceManualPartition(base.DataSource):
     def to_dask(self):
         self._get_schema()
         return self._dataframe
-
-    def to_ibis(self):
-        """
-        Create an ibis expression for the data source.
-        The sql_expr for the source must be a table, not a table expression.
-        The ibis expression is not partitioned.
-        """
-        client = make_ibis_client(self._uri)
-        if self._sql_expr not in client.list_tables():
-            raise ValueError("Only full tables can be used in to_ibis")
-        else:
-            return client.table(self._sql_expr)
 
     def read(self):
         self._get_schema()

--- a/intake_sql/sql_cat.py
+++ b/intake_sql/sql_cat.py
@@ -15,7 +15,8 @@ class SQLCatalog(Catalog):
     name = 'sql_cat'
     version = __version__
 
-    def __init__(self, uri, views=False, **kwargs):
+    def __init__(self, uri, views=False, sql_kwargs=None, **kwargs):
+        self.sql_kwargs = sql_kwargs or {}
         self.uri = uri
         self.views = views
         super(SQLCatalog, self).__init__(**kwargs)
@@ -32,7 +33,7 @@ class SQLCatalog(Catalog):
                 if c.primary_key:
                     description = 'SQL table %s from %s' % (name, self.uri)
                     args = {'uri': self.uri, 'table': name, 'index': c.name,
-                            'sql_kwargs': {}}
+                            'sql_kwargs': self.sql_kwargs}
                     e = LocalCatalogEntry(name, description, 'sql_auto', True,
                                           args, {}, {}, {}, "", getenv=False,
                                           getshell=False)

--- a/intake_sql/sql_cat.py
+++ b/intake_sql/sql_cat.py
@@ -32,7 +32,7 @@ class SQLCatalog(Catalog):
                 if c.primary_key:
                     description = 'SQL table %s from %s' % (name, self.uri)
                     args = {'uri': self.uri, 'table': name, 'index': c.name,
-                            'sql_kwargs': self.kwargs}
+                            'sql_kwargs': {}}
                     e = LocalCatalogEntry(name, description, 'sql_auto', True,
                                           args, {}, {}, {}, "", getenv=False,
                                           getshell=False)

--- a/tests/test_intake_sql.py
+++ b/tests/test_intake_sql.py
@@ -57,10 +57,3 @@ def test_to_ibis(temp_db):
     expr = s.to_ibis()
     d2 = expr.execute().set_index('p')
     assert df.equals(d2)
-    # Manual-partition (to_ibis ignores partitioning)
-    s = SQLSourceManualPartition(uri, table,
-               where_values=['WHERE p < 20', 'WHERE p >= 20'],
-               sql_kwargs=dict(index_col='p'))
-    expr = s.to_ibis()
-    d2 = expr.execute().set_index('p')
-    assert df.equals(d2)


### PR DESCRIPTION
Partner to intake/intake#395

Given a SQL data source and a table, we can produce ibis clients for constructing lazily evaluated expressions. Currently targeting the ibis backends that use SQLAlchemy, so PostgreSQL, SQLite, and MySQL (I've tested the former two).