### PR TITLE
Allow SQLCatalog to work for tables without a primary key

### DIFF
--- a/intake_sql/sql_cat.py
+++ b/intake_sql/sql_cat.py
@@ -23,20 +23,34 @@ class SQLCatalog(Catalog):
 
     def _load(self):
         import sqlalchemy
-        from intake_sql import SQLSourceAutoPartition
+        from intake_sql import SQLSource, SQLSourceAutoPartition
         engine = sqlalchemy.create_engine(self.uri)
         meta = sqlalchemy.MetaData(bind=engine)
-        meta.reflect(views=self.views)
+        meta.reflect(views=self.views, schema=self.sql_kwargs.get("schema"))
         self._entries = {}
         for name, table in meta.tables.items():
+            description = 'SQL table %s from %s' % (name, self.uri)
             for c in table.columns:
+                # We use table.name instead of the metadata key here as it
+                # does not include the schema name, which is handled
+                # by the `sql_kwargs`.
                 if c.primary_key:
-                    description = 'SQL table %s from %s' % (name, self.uri)
-                    args = {'uri': self.uri, 'table': name, 'index': c.name,
+                    args = {'uri': self.uri, 'table': table.name, 'index': c.name,
                             'sql_kwargs': self.sql_kwargs}
-                    e = LocalCatalogEntry(name, description, 'sql_auto', True,
+                    e = LocalCatalogEntry(table.name, description, 'sql_auto', True,
                                           args, {}, {}, {}, "", getenv=False,
                                           getshell=False)
                     e._plugin = [SQLSourceAutoPartition]
-                    self._entries[name] = e
+                    self._entries[table.name] = e
                     break
+            else:
+                args = {
+                    'uri': self.uri,
+                    'sql_expr': table.name,
+                    'sql_kwargs': self.sql_kwargs
+                }
+                e = LocalCatalogEntry(name,description, 'sql', True,
+                                      args, {}, {}, {}, "", getenv=False,
+                                      getshell=False)
+                e._plugin = [SQLSource]
+                self._entries[table.name] = e

--- a/tests/test_sql_cat.py
+++ b/tests/test_sql_cat.py
@@ -1,5 +1,5 @@
 from intake_sql.sql_cat import SQLCatalog
-from .utils import temp_db, df
+from .utils import temp_db, df, df2
 import intake
 import os
 here = os.path.abspath(os.path.dirname(__file__))
@@ -9,20 +9,27 @@ intake.registry['sql_cat'] = SQLCatalog
 
 
 def test_cat(temp_db):
-    table, uri = temp_db
+    table, table_nopk, uri = temp_db
     cat = SQLCatalog(uri)
     assert table in cat
+    assert table_nopk in cat
     d2 = getattr(cat, table).read()
     assert df.equals(d2)
+    d_noindex = getattr(cat, table_nopk).read()
+    assert df2.equals(d_noindex)
+    
 
 
 def test_yaml_cat(temp_db):
-    table, uri = temp_db
+    table, table_nopk, uri = temp_db
     os.environ['TEST_SQLITE_URI'] = uri  # used in catalog default
     cat = intake.Catalog(os.path.join(here, 'cat.yaml'))
     assert 'tables' in cat
     cat2 = cat.tables()
     assert isinstance(cat2, SQLCatalog)
-    assert 'temp' in list(cat2)
+    assert table in list(cat2)
+    assert table_nopk in list(cat2)
     d2 = cat.tables.temp.read()
     assert df.equals(d2)
+    d_noindex = getattr(cat.tables, table_nopk).read()
+    assert df2.equals(d_noindex)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,6 +12,11 @@ df = pd.DataFrame({
     'c': np.random.choice(['a', 'b', 'c', 'd'], size=100)
 })
 df.index.name = 'p'
+df2 = pd.DataFrame({
+    'd': np.random.rand(100),
+    'e': np.random.randint(100),
+    'f': np.random.choice(['a', 'b', 'c', 'd'], size=100)
+})
 
 
 @pytest.fixture(scope='module')
@@ -26,9 +31,15 @@ def temp_db():
         a REAL NOT NULL,
         b BIGINT NOT NULL,
         c TEXT NOT NULL);""")
+    con.execute(
+        """CREATE TABLE temp2 (
+        d REAL NOT NULL,
+        e BIGINT NOT NULL,
+        f TEXT NOT NULL);""")
     df.to_sql('temp', uri, if_exists='append')
+    df2.to_sql('temp_nopk', uri, if_exists='append', index=False)
     try:
-        yield 'temp', uri
+        yield 'temp', 'temp_nopk', uri
     finally:
         if os.path.isfile(f):
             os.remove(f)


### PR DESCRIPTION
I was surprised to find that the `SQLCatalog` driver silently ignored tables missing a primary key, as it only knows how to construct `SQLSourceAutoPartition` entries. I think it would be reasonable to fall back on a regular `SQLSource` entry in that case.

This also includes a fix for the case when a schema is specified args.